### PR TITLE
Added link to another event recap

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,6 +90,14 @@
       <div id="event" class="row">
         <h2>Events</h2>
         <div class="row">
+
+          <div class="col-xs-6 col-md-3">
+            <a href="https://medium.com/@gregory.lt.wong/freecodecamp-hong-kong-meet-up-recap-programming-101-79805c4611eb" class="thumbnail">
+              <img src="https://cdn-images-1.medium.com/max/2000/1*-DgEh8wu9IHSSClDUU0o7g.jpeg" alt="">
+              <p class="title">freeCodeCamp Hong Kong — Meet Up Recap (Programming 101)</p>
+            </a>
+          </div>
+
           <div class="col-xs-6 col-md-3">
             <a href="https://medium.com/@gregory.lt.wong/freecodecamp-hong-kong-august-meet-up-recap-intro-to-php-913b4506a26f" class="thumbnail">
               <img src="https://cdn-images-1.medium.com/max/1600/1*hnrIcmlazqwWqRJAwxvs3g.jpeg" alt="">


### PR DESCRIPTION
I added a link to our latest event (the talk by Isaac). This shows up as another item in the events section.

Possible display issue to address in the future: The images have different dimensions and the grid display might not be aligned perfectly.

For example:
![screen shot 2017-09-15 at 4 21 29 pm](https://user-images.githubusercontent.com/1437804/30473232-446628b8-9a32-11e7-9a50-98fed3399731.png)

