### PR TITLE
Resolve #29 by creating CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+## Guide to Every Contributor
+Your contribution is more than welcome!
+
+For better project maintenance, please read this guide before creating issues and pull requests. 
+
+This repository is currently maintained by a team of volunteers from freeCodeCamp Hong Kong [@FreeCodeCampHongKong/admin](https://github.com/orgs/FreeCodeCampHongKong/teams/admin/members). Feel free to contact us if you encounter any problems with / have any suggestions for this repository.
+
+### Add a new issue
+If you want to add a new issue or propose a particular change for the website (e.g. building a new template, adding a new section, or migrating to a new platform), add a new issue and assign a relevant label to it.
+
+### Work on an issue
+1. Pick an issue that you can contribute to by assigning yourself the task, so others will know that you have picked up the task. If you are unable to do so, leave your name under the issue and someone will send you an invitation link to the org. Assign yourself after accepting the invitation.
+2. Start a new branch for the issue if it hasn't been created already. Alternatively, you can fork the repo and work within the forked repo as well.
+3. Once you have committed code in the new branch, submit a pull request and ask for a review.
+4. Once the code changes get reviewed and tested, they will be merged to the respective branch for production.
+5. If your pull request is successful, your contribution will be shown in your Github account.
+
+### Review pull requests, merge and delete merged branches
+1. Contact the administration team if you can be a reviewer.
+2. Reviewers can preview the changes by using netlify. Simply click on "Details" to see a preview of the deployed page. If unsure, always test the code changes locally before merging to the respective branch. 
+![example](https://user-images.githubusercontent.com/1437804/30513349-564e4bf2-9b34-11e7-92fa-29e13b36e1ea.png)
+3. Leave reviews if further changes are required for the pull request.
+4. Before pressing the merge button, edit the commit message to ensure present tense is used and an issue number is added (e.g. #9) for tracking. You can also [close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/) if you reference the issue in your pull request description or commit message. (e.g. "close #1", "fix #1", "resolve #1", etc).
+5. Delete the branch according to the GitHub instructions.

--- a/README.md
+++ b/README.md
@@ -17,16 +17,6 @@ For better project maintenance, please read [this guide](CONTRIBUTING.md) before
 
 This repository is currently maintained by a team of volunteers from freeCodeCamp Hong Kong [@FreeCodeCampHongKong/admin](https://github.com/orgs/FreeCodeCampHongKong/teams/admin/members). Feel free to contact us if you encounter any problems with / have any suggestions for this repository.
 
-### Review, merge and delete merged branches
-1. Contact the administration team if you can be a reviewer.
-2. Reviewers can preview the changes by using netlify. Simply click on "Details" to see a preview of the deployed page.
-![example](https://user-images.githubusercontent.com/1437804/30513349-564e4bf2-9b34-11e7-92fa-29e13b36e1ea.png)
-If unsure, always test the code changes locally before merging to the respective branch. 
-3. Leave reviews if further changes are required for the pull request.
-4. Before pressing the merge button, edit the commit message to ensure present tense is used and an issue number is added (e.g. #9) for tracking. You can also [close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/) if you reference the issue in your pull request description or commit message. (e.g. "close #1", "fix #1", "resolve #1", etc).
-5. Delete the branch according to the GitHub instructions.
-
-
 ## Site setup
 
 We set up this site using GitHub Pages. For more information, please visit [GitHub Pages](https://pages.github.com/).

--- a/README.md
+++ b/README.md
@@ -10,23 +10,12 @@ We are a group of Hong Kong-based coders and freeCodeCampers. We learn to code t
 
 ### Or join our [Facebook group](https://zh-hk.facebook.com/groups/free.code.camp.hk/)!
 
-
 ## Guide to every Contributor
 Your contribution is more than welcome!
 
-For better project maintenance, please read this guide before making commits and pull requests. 
+For better project maintenance, please read [this guide](CONTRIBUTING.md) before creating issues and pull requests. 
 
 This repository is currently maintained by a team of volunteers from freeCodeCamp Hong Kong [@FreeCodeCampHongKong/admin](https://github.com/orgs/FreeCodeCampHongKong/teams/admin/members). Feel free to contact us if you encounter any problems with / have any suggestions for this repository.
-
-### Pick an issue
-1. Pick an issue that you can contribute to by assigning yourself the task, so others will know that you have picked up the task. If you are unable to do so, leave your name under the issue and someone will send you an invitation link to the org. Assign yourself after accepting the invitation.
-2. Start a new branch for the issue if it hasn't been created already. Alternatively, you can fork the repo and work within the forked repo as well.
-3. Once you have committed code in the new branch, submit a pull request and ask for a review.
-4. Once the code changes get reviewed and tested, they will be merged to the respective branch for production.
-5. If your pull request is successful, your contribution will be shown in your Github account.
-
-### Add a new issue
-If you want to add a new issue or propose a particular change for the website (e.g. building a new template, adding a new section, or migrating to a new platform), add a new issue and assign a relevant label to it.
 
 ### Review, merge and delete merged branches
 1. Contact the administration team if you can be a reviewer.


### PR DESCRIPTION
To resolve #29 :

Create `CONTRIBUTING.md` and move the contributor guidelines there so that people can easily reference it. In addition, by doing this, GitHub will show a link to it every time someone creates an issue or a pull request.

![image](https://help.github.com/assets/images/help/pull_requests/Contributing-guidelines.jpg)