### PR TITLE
fixed navbar covering the top of the page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -6,6 +6,11 @@
   border: none;
 }
 
+body {
+  /* required so that the navbar doesn't cover the top of the page */
+  padding-top: 50px;
+}
+
 .event .row {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Fixes navbar covering the top of the page. (Introduced after adding class `fixed-navbar-top` to the navbar.)

The heads of the people aren't covered in the "After" screenshot.

### Before:
![screen shot 2017-09-20 at 1 04 17 am](https://user-images.githubusercontent.com/1437804/30605954-a137fd82-9da2-11e7-9902-2aa954fcb9ac.png)

### After:
![screen shot 2017-09-20 at 1 25 35 am](https://user-images.githubusercontent.com/1437804/30605968-a887bbea-9da2-11e7-95fb-e54d6aaceb63.png)
