### PR TITLE
Added link to another event recap

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -11,9 +11,14 @@ body {
   padding-top: 50px;
 }
 
-.event .row {
+.row.display-flex {
   display: flex;
   flex-wrap: wrap;
+}
+
+.row.display-flex > [class*='col-'] {
+  display: flex;
+  flex-direction: column;
 }
 
 .carousel-inner img {

--- a/index.html
+++ b/index.html
@@ -94,31 +94,37 @@
     <div class="container">
       <div id="event" class="row">
         <h2>Events</h2>
-        <div class="row">
-          <div class="col-xs-6 col-md-3">
-            <a href="https://medium.com/@gregory.lt.wong/freecodecamp-hong-kong-august-meet-up-recap-intro-to-php-913b4506a26f" class="thumbnail">
-              <img src="https://cdn-images-1.medium.com/max/1600/1*hnrIcmlazqwWqRJAwxvs3g.jpeg" alt="August 2017 meetup - Jeff teaching PhP basics">
-              <p class="title">Hong Kong — August Meet Up Recap (Intro to PHP)</p>
-            </a>
-          </div>
-          <div class="col-xs-6 col-md-3">
-            <a href="https://medium.com/@gregory.lt.wong/freecodecamp-hong-kong-july-meet-up-recap-e3446f09858e" class="thumbnail">
-              <img src="https://cdn-images-1.medium.com/max/1600/1*wZZ0Fh6Gm7nS5GTbcnylOg.jpeg" alt="July 2017 meetup - casual sharing">
-              <p class="title">freeCodeCamp Hong Kong - July Meet Up Recap</p>
-            </a>
-          </div>
-          <div class="col-xs-6 col-md-3">
-            <a href="https://medium.com/@gregory.lt.wong/freecodecamp-hong-kong-large-scale-community-building-855fb642b0e6" class="thumbnail">
-              <img src="https://cdn-images-1.medium.com/max/2000/1*dDIcbxAeUfIy3FQUtFcbKQ.jpeg" alt="June 2017 meetup - casual sharing">
-              <p class="title">freeCodeCamp Hong Kong - Large Scale Community Building</p>
-            </a>
-          </div>
-          <div class="col-xs-6 col-md-3">
-            <a href="https://medium.com/@gregory.lt.wong/freecodecamp-hong-kong-june-meet-up-recap-ebd833a76291" class="thumbnail">
-              <img src="https://cdn-images-1.medium.com/max/2000/1*gd1mg6pCVrrHhbmMUlNZZg.jpeg" alt="June 2017 meetup - First meetup at Accelerate WanChai">
-              <p class="title">freeCodeCamp Hong Kong - June Meet Up Recap</p>
-            </a>
-          </div>
+      </div>
+      <div class="row display-flex">
+        <div class="col-xs-6 col-md-3">
+          <a href="https://medium.com/@gregory.lt.wong/freecodecamp-hong-kong-meet-up-recap-programming-101-79805c4611eb" class="thumbnail">
+            <img src="https://cdn-images-1.medium.com/max/2000/1*-DgEh8wu9IHSSClDUU0o7g.jpeg" alt="September 2017 meetup - Isaac teaching programming concepts">
+            <p class="title">freeCodeCamp Hong Kong — September Meet Up Recap (Programming 101)</p>
+          </a>
+        </div>
+        <div class="col-xs-6 col-md-3">
+          <a href="https://medium.com/@gregory.lt.wong/freecodecamp-hong-kong-august-meet-up-recap-intro-to-php-913b4506a26f" class="thumbnail">
+            <img src="https://cdn-images-1.medium.com/max/1600/1*hnrIcmlazqwWqRJAwxvs3g.jpeg" alt="August 2017 meetup - Jeff teaching PhP basics">
+            <p class="title">Hong Kong — August Meet Up Recap (Intro to PHP)</p>
+          </a>
+        </div>
+        <div class="col-xs-6 col-md-3">
+          <a href="https://medium.com/@gregory.lt.wong/freecodecamp-hong-kong-july-meet-up-recap-e3446f09858e" class="thumbnail">
+            <img src="https://cdn-images-1.medium.com/max/1600/1*wZZ0Fh6Gm7nS5GTbcnylOg.jpeg" alt="July 2017 meetup - casual sharing">
+            <p class="title">freeCodeCamp Hong Kong - July Meet Up Recap</p>
+          </a>
+        </div>
+        <div class="col-xs-6 col-md-3">
+          <a href="https://medium.com/@gregory.lt.wong/freecodecamp-hong-kong-large-scale-community-building-855fb642b0e6" class="thumbnail">
+            <img src="https://cdn-images-1.medium.com/max/2000/1*dDIcbxAeUfIy3FQUtFcbKQ.jpeg" alt="June 2017 meetup - casual sharing">
+            <p class="title">freeCodeCamp Hong Kong - Large Scale Community Building</p>
+          </a>
+        </div>
+        <div class="col-xs-6 col-md-3">
+          <a href="https://medium.com/@gregory.lt.wong/freecodecamp-hong-kong-june-meet-up-recap-ebd833a76291" class="thumbnail">
+            <img src="https://cdn-images-1.medium.com/max/2000/1*gd1mg6pCVrrHhbmMUlNZZg.jpeg" alt="June 2017 meetup - First meetup at Accelerate WanChai">
+            <p class="title">freeCodeCamp Hong Kong - June Meet Up Recap</p>
+          </a>
         </div>
       </div>
       <hr>


### PR DESCRIPTION
This PR supersedes #20 .

Summary:
1. I added another event link in the **Events** sections.
1. At the same time, rows should not be children of other rows, so I closed the row containing the `h2` element, and started a new row for the event columns / blocks.
1. Finally, there was an issue when the site was viewed on narrow screens, as some of the events would be "pushed" aside when the previous row's events had different heights. This fix changes the height of these event col / blocks so that this problem doesn't happen.