### PR TITLE
fixed spelling so it's consistent across the page

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
       <!-- Collect the nav links, forms, and other content for toggling -->
       <div class="collapse navbar-collapse text-center" id="bs-example-navbar-collapse-1">
         <ul class="nav navbar-nav navbar-right">
-          <li><a href="#event">Event</a></li>
+          <li><a href="#events">Events</a></li>
           <li><a href="https://www.facebook.com/groups/free.code.camp.hk/" target="_blank"><i class="fa fa-facebook-official fa-lg" aria-hidden="true"></i></a></i></li>
           <li><a href="https://github.com/FreeCodeCampHongKong/" target="_blank"><i class="fa fa-github fa-lg" aria-hidden="true"></i></a></i></li>
           <li><a href="https://gitter.im/FreeCodeCampHongKong" target="_blank"><i class="fa fa-comments fa-lg" aria-hidden="true"></i></a></i></li>
@@ -92,7 +92,7 @@
 
     <!-- <img class="img-responsive" src="img/landing.jpeg" alt="Group photo of Free Code Camp Hong Kong members"> -->
     <div class="container">
-      <div id="event" class="row">
+      <div id="events" class="row">
         <h2>Events</h2>
         <div class="row">
           <div class="col-xs-6 col-md-3">


### PR DESCRIPTION
It says **Event** in the navbar and **Events** in the section title. I've changed it all to say **Events** so it's more consistent.